### PR TITLE
Fix uses_scene_transition_routine: version string

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -681,7 +681,7 @@ impl GameManagerFinder {
     }
 
     pub fn get_version_vec(&self, process: &Process) -> Option<Vec<i32>> {
-        Some(self.get_version_string(process)?.split(".").map(|s| {
+        Some(self.get_version_string(process)?.split('.').map(|s| {
             s.parse().unwrap_or(0)
         }).collect())
     }

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -89,6 +89,7 @@ pub const UI_STATE_PAUSED: i32 = 7;
 pub const HERO_TRANSITION_STATE_WAITING_TO_ENTER_LEVEL: i32 = 2;
 
 struct GameManagerPointers {
+    version_number: UnityPointer<4>,
     scene_name: UnityPointer<2>,
     next_scene_name: UnityPointer<2>,
     game_state: UnityPointer<2>,
@@ -107,6 +108,7 @@ struct GameManagerPointers {
 impl GameManagerPointers {
     fn new() -> GameManagerPointers {
         GameManagerPointers {
+            version_number: UnityPointer::new("GameManager", 0, &["_instance", "<inputHandler>k__BackingField", "debugInfo", "versionNumber"]),
             scene_name: UnityPointer::new("GameManager", 0, &["_instance", "sceneName"]),
             next_scene_name: UnityPointer::new("GameManager", 0, &["_instance", "nextSceneName"]),
             game_state: UnityPointer::new("GameManager", 0, &["_instance", "gameState"]),
@@ -127,7 +129,7 @@ impl GameManagerPointers {
 // --------------------------------------------------------
 
 struct PlayerDataPointers {
-    version: UnityPointer<3>,
+    version: UnityPointer<4>,
     health: UnityPointer<3>,
     fireball_level: UnityPointer<3>,
     quake_level: UnityPointer<3>,
@@ -672,7 +674,9 @@ impl GameManagerFinder {
     }
 
     pub fn get_version_string(&self, process: &Process) -> Option<String> {
-        let s = self.player_data_pointers.version.deref(process, &self.module, &self.image).ok()?;
+        let s = [&self.pointers.version_number, &self.player_data_pointers.version].into_iter().find_map(|ptr| {
+            ptr.deref(process, &self.module, &self.image).ok()
+        })?;
         read_string_object::<SCENE_PATH_SIZE>(process, s)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ impl LoadRemover {
         let hero_transition_state = maybe_hero_transition_state.unwrap_or_default();
         let maybe_tile_map_dirty = game_manager_finder.tile_map_dirty(process);
         let tile_map_dirty = maybe_tile_map_dirty.unwrap_or_default();
-        let uses_scene_transition_routine = game_manager_finder.uses_scene_transition_routine()?;
+        let uses_scene_transition_routine = game_manager_finder.uses_scene_transition_routine(process).unwrap_or_default();
         let is_game_time_paused =
             (game_state == GAME_STATE_PLAYING && teleporting && !hazard_respawning)
             || (self.look_for_teleporting)


### PR DESCRIPTION
Get a version string, parse it into a version vec, and use that for `uses_scene_transition_routine`.

TODO:
- [x] look into getting the version string the same way `LiveSplit.HollowKnight` does
- [x] test it on a version before the split
- [x] test it on a version after the split