### PR TITLE
Splits WaterwaysEntry, FogCanyonEntry

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -84,7 +84,8 @@ pub const CRYSTAL_PEAK_ENTRY_SCENES: &[&str] = &[
 
 pub const FOG_CANYON_ENTRY_SCENES: &[&str] = &[
     "Fungus3_01", // West Fog Canyon entrance from Greenpath
-    "Fungus3_02", // West Fog Canyon entrance from Queen's Station
+    "Fungus3_02", // West Fog Canyon entrance from Queen's Station or QGA
+    "Fungus3_24", // West Fog Canyon entrance from Queen's Gardens via Overgrown Mound
     "Fungus3_26", // East Fog Canyon, where the Crossroads acid and Leg Eater acid entrances meet
 ];
 

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -82,6 +82,12 @@ pub const CRYSTAL_PEAK_ENTRY_SCENES: &[&str] = &[
     "Mines_10",
 ];
 
+pub const FOG_CANYON_ENTRY_SCENES: &[&str] = &[
+    "Fungus3_01", // West Fog Canyon entrance from Greenpath
+    "Fungus3_02", // West Fog Canyon entrance from Queen's Station
+    "Fungus3_26", // East Fog Canyon, where the Crossroads acid and Leg Eater acid entrances meet
+];
+
 pub const QUEENS_GARDENS_ENTRY_SCENES: &[&str] = &[
     "Fungus3_34",
     "Deepnest_43",

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -82,6 +82,12 @@ pub const CRYSTAL_PEAK_ENTRY_SCENES: &[&str] = &[
     "Mines_10",
 ];
 
+pub const WATERWAYS_ENTRY_SCENES: &[&str] = &[
+    "Waterways_01", // Simple Key manhole entrance
+    // Note: Waterways_06 does not show the Area Text
+    "Waterways_07", // Where the Spike-tunnel and KE-Tram-CDash entrances meet
+];
+
 pub const FOG_CANYON_ENTRY_SCENES: &[&str] = &[
     "Fungus3_01", // West Fog Canyon entrance from Greenpath
     "Fungus3_02", // West Fog Canyon entrance from Queen's Station or QGA

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1354,6 +1354,10 @@ pub enum Split {
     /// 
     /// Splits when opening the Waterways Manhole
     WaterwaysManhole,
+    /// Waterways (Transition)
+    /// 
+    /// Splits on transition to Waterways
+    WaterwaysEntry,
     /// Royal Waterways (Area)
     /// 
     /// Splits when entering Royal Waterways text first appears
@@ -1538,6 +1542,10 @@ pub enum Split {
     ColosseumGoldExit,
     // endregion: Colosseum
     // region: Fog Canyon
+    /// Fog Canyon (Transition)
+    /// 
+    /// Splits on transition to Fog Canyon
+    FogCanyonEntry,
     /// Fog Canyon (Area)
     /// 
     /// Splits when entering Fog Canyon text first appears
@@ -1789,6 +1797,7 @@ pub fn transition_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &GameManag
         Split::CrystalMoundExit => p.old.starts_with("Mines_35") && p.current != p.old,
         // endregion: Peak
         // region: Waterways
+        Split::WaterwaysEntry => starts_with_any(p.current, WATERWAYS_ENTRY_SCENES) && p.current != p.old,
         Split::DungDefenderExit => p.old == "Waterways_05" && p.current == "Abyss_01",
         Split::TransTear => pds.has_acid_armour(prc, g) && p.current != p.old,
         Split::MenuIsmasTear => pds.has_acid_armour(prc, g) && is_menu(p.current),
@@ -1821,6 +1830,7 @@ pub fn transition_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &GameManag
         Split::ColosseumGoldExit => pds.colosseum_bronze_completed(prc, g) && !p.current.starts_with("Room_Colosseum_Gold"),
         // endregion: Colosseum
         // region: Fog Canyon
+        Split::FogCanyonEntry => starts_with_any(p.current, FOG_CANYON_ENTRY_SCENES) && p.current != p.old,
         Split::TeachersArchive => p.current.starts_with("Fungus3_archive") && !p.old.starts_with("Fungus3_archive"),
         // endregion: Fog Canyon
         // region: Queen's Gardens


### PR DESCRIPTION
The `WaterwaysEntry` split includes the Simple key manhole, Spike-tunnel, and Tram-CDash entrances.

The `FogCanyonEntry` split includes East and West entrances.