### PR TITLE
Splits that should Skip

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -400,7 +400,7 @@ struct PlayerDataPointers {
     killed_black_knight: UnityPointer<3>,
     collector_defeated: UnityPointer<3>,
     nailsmith_killed: UnityPointer<3>,
-    // nailsmith_spared: UnityPointer<3>,
+    nailsmith_spared: UnityPointer<3>,
     visited_mines: UnityPointer<3>,
     kills_zombie_miner: UnityPointer<3>,
     // Crystal Guardian
@@ -680,7 +680,7 @@ impl PlayerDataPointers {
             killed_black_knight: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "killedBlackKnight"]),
             collector_defeated: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "collectorDefeated"]),
             nailsmith_killed: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "nailsmithKilled"]),
-            // nailsmith_spared: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "nailsmithSpared"]),
+            nailsmith_spared: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "nailsmithSpared"]),
             visited_mines: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "visitedMines"]),
             kills_zombie_miner: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "killsZombieMiner"]),
             defeated_mega_beam_miner: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "defeatedMegaBeamMiner"]),
@@ -1677,11 +1677,9 @@ impl GameManagerFinder {
     pub fn nailsmith_killed(&self, process: &Process) -> Option<bool> {
         self.player_data_pointers.nailsmith_killed.deref(process, &self.module, &self.image).ok()
     }
-    /*
     pub fn nailsmith_spared(&self, process: &Process) -> Option<bool> {
         self.player_data_pointers.nailsmith_spared.deref(process, &self.module, &self.image).ok()
     }
-    */
 
     pub fn visited_mines(&self, process: &Process) -> Option<bool> {
         self.player_data_pointers.visited_mines.deref(process, &self.module, &self.image).ok()

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1580,7 +1580,8 @@ pub enum Split {
     /// Radiance Dream Entry (Event)
     /// 
     /// Splits upon entering the Radiance dream
-    // TODO: Skips upon killing the Hollow Knight (requires ordered splits)
+    /// 
+    /// Skips upon killing the Hollow Knight
     HollowKnightDreamnail,
     /// Segment Practice - Radiance (Boss)
     /// 
@@ -2601,7 +2602,9 @@ pub fn transition_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &GameManag
         Split::TransVS => should_split(1 <= pds.get_fireball_level(prc, g) && p.current != p.old),
         Split::SalubraExit => should_split(p.old == "Room_Charm_Shop" && p.current != p.old),
         Split::EnterHollowKnight => should_split(p.current == "Room_Final_Boss_Core" && p.current != p.old),
-        Split::HollowKnightDreamnail => should_split(p.current.starts_with("Dream_Final") && p.current != p.old),
+        Split::HollowKnightDreamnail => should_split(p.current.starts_with("Dream_Final") && p.current != p.old).or_else(|| {
+            should_skip(g.killed_hollow_knight(prc).is_some_and(|k| k))
+        }),
         // endregion: Crossroads
         // region: Greenpath
         Split::EnterGreenpath => should_split(p.current.starts_with("Fungus1_01") && !p.old.starts_with("Fungus1_01")),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -36,6 +36,14 @@ fn should_split(b: bool) -> SplitterAction {
     }
 }
 
+fn should_skip(b: bool) -> SplitterAction {
+    if b {
+        SplitterAction::Skip
+    } else {
+        SplitterAction::Pass
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, Gui, Ord, PartialEq, PartialOrd, RadioButtonOptions, Serialize)]
 pub enum Split {
     // region: Start, End, and Menu

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1843,6 +1843,12 @@ pub enum Split {
     /// 
     /// Splits when Nailsmith is killed
     NailsmithKilled,
+    /// Nailsmith Killed/Spared (Event)
+    /// 
+    /// Splits when Nailsmith is killed
+    /// 
+    /// Skips when nailsmith is spared
+    NailsmithChoice,
     // endregion: City
     // region: Peak
     /// Crystal Peak Entry (Transition)
@@ -3258,6 +3264,9 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::Collector => should_split(g.collector_defeated(p).is_some_and(|k| k)),
         Split::TransCollector => { pds.collector_defeated(p, g); should_split(false) },
         Split::NailsmithKilled => should_split(g.nailsmith_killed(p).is_some_and(|k| k)),
+        Split::NailsmithChoice => should_split(g.nailsmith_killed(p).is_some_and(|k| k)).or_else(|| {
+            should_skip(g.nailsmith_spared(p).is_some_and(|s| s))
+        }),
         // endregion: City
         // region: Peak
         Split::CrystalPeak => should_split(g.visited_mines(p).is_some_and(|v| v)),


### PR DESCRIPTION
Adds skip conditions for `HollowKnightDreamnail` and `NailsmithChoice`.

Similar, if more complicated, skip conditions could be used for Colo wave splits in the future.