### PR TITLE
Splits for Grub combos and Dream Trees 

### DIFF
--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -1510,6 +1510,10 @@ impl GameManagerFinder {
         read_string_list_object::<SCENE_PATH_SIZE>(process, l)
     }
 
+    pub fn grub_waterways_isma(&self, process: &Process) -> Option<bool> {
+        Some(self.scenes_grub_rescued(process)?.contains(&"Waterways_13".to_string()))
+    }
+
     pub fn kills_grub_mimic(&self, process: &Process) -> Option<i32> {
         self.player_data_pointers.kills_grub_mimic.deref(process, &self.module, &self.image).ok()
     }
@@ -2390,6 +2394,17 @@ impl PlayerDataStore {
 
     pub fn incremented_grubs_collected(&mut self, process: &Process, game_manager_finder: &GameManagerFinder) -> bool {
         self.incremented_i32(process, game_manager_finder, "grubs_collected", &game_manager_finder.player_data_pointers.grubs_collected)
+    }
+
+    pub fn grub_waterways_isma(&mut self, p: &Process, g: &GameManagerFinder) -> bool {
+        if !g.is_game_state_non_menu(p) {
+            return self.map_bool.get("grub_waterways_isma").unwrap_or(&false).clone();
+        };
+        let Some(b) = g.grub_waterways_isma(p) else {
+            return self.map_bool.get("grub_waterways_isma").unwrap_or(&false).clone();
+        };
+        self.map_bool.insert("grub_waterways_isma", b);
+        b
     }
 
     pub fn incremented_ore(&mut self, process: &Process, game_manager_finder: &GameManagerFinder) -> bool {

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -345,6 +345,7 @@ struct PlayerDataPointers {
     royal_charm_state: UnityPointer<3>,
     got_shade_charm: UnityPointer<3>,
     grubs_collected: UnityPointer<3>,
+    scenes_grub_rescued: UnityPointer<3>,
     kills_grub_mimic: UnityPointer<3>,
     dream_orbs: UnityPointer<3>,
     map_dirtmouth: UnityPointer<3>,
@@ -655,6 +656,7 @@ impl PlayerDataPointers {
             royal_charm_state: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "royalCharmState"]),
             got_shade_charm: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "gotShadeCharm"]),
             grubs_collected: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "grubsCollected"]),
+            scenes_grub_rescued: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "scenesGrubRescued"]),
             kills_grub_mimic: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "killsGrubMimic"]),
             dream_orbs: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "dreamOrbs"]),
             map_dirtmouth: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "mapDirtmouth"]),
@@ -1501,6 +1503,11 @@ impl GameManagerFinder {
 
     pub fn grubs_collected(&self, process: &Process) -> Option<i32> {
         self.player_data_pointers.grubs_collected.deref(process, &self.module, &self.image).ok()
+    }
+
+    pub fn scenes_grub_rescued(&self, process: &Process) -> Option<Vec<String>> {
+        let l = self.player_data_pointers.scenes_grub_rescued.deref(process, &self.module, &self.image).ok()?;
+        read_string_list_object::<SCENE_PATH_SIZE>(process, l)
     }
 
     pub fn kills_grub_mimic(&self, process: &Process) -> Option<i32> {

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -348,6 +348,7 @@ struct PlayerDataPointers {
     scenes_grub_rescued: UnityPointer<3>,
     kills_grub_mimic: UnityPointer<3>,
     dream_orbs: UnityPointer<3>,
+    scenes_encountered_dream_plant_c: UnityPointer<3>,
     map_dirtmouth: UnityPointer<3>,
     map_crossroads: UnityPointer<3>,
     map_greenpath: UnityPointer<3>,
@@ -659,6 +660,7 @@ impl PlayerDataPointers {
             scenes_grub_rescued: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "scenesGrubRescued"]),
             kills_grub_mimic: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "killsGrubMimic"]),
             dream_orbs: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "dreamOrbs"]),
+            scenes_encountered_dream_plant_c: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "scenesEncounteredDreamPlantC"]),
             map_dirtmouth: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "mapDirtmouth"]),
             map_crossroads: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "mapCrossroads"]),
             map_greenpath: UnityPointer::new("GameManager", 0, &["_instance", "playerData", "mapGreenpath"]),
@@ -1520,6 +1522,11 @@ impl GameManagerFinder {
 
     pub fn dream_orbs(&self, process: &Process) -> Option<i32> {
         self.player_data_pointers.dream_orbs.deref(process, &self.module, &self.image).ok()
+    }
+
+    pub fn scenes_encountered_dream_plant_c(&self, process: &Process) -> Option<Vec<String>> {
+        let l = self.player_data_pointers.scenes_encountered_dream_plant_c.deref(process, &self.module, &self.image).ok()?;
+        read_string_list_object::<SCENE_PATH_SIZE>(process, l)
     }
 
     pub fn map_dirtmouth(&self, process: &Process) -> Option<bool> {

--- a/src/hollow_knight_memory.rs
+++ b/src/hollow_knight_memory.rs
@@ -2540,7 +2540,10 @@ fn read_string_list_object<const SN: usize>(process: &Process, a: Address64) -> 
     for i in 0..(vn as u64) {
         let item_offset = ARRAY_CONTENTS_OFFSET + POINTER_SIZE * i;
         let item_ptr: Address64 = process.read_pointer_path64(array_ptr, &[item_offset]).ok()?;
-        let s = read_string_object::<SN>(process, item_ptr).unwrap_or_default();
+        if item_ptr.is_null() {
+            continue;
+        }
+        let s = read_string_object::<SN>(process, item_ptr)?;
         v.push(s);
     }
     Some(v)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,12 +60,25 @@ async fn main() {
                     auto_reset = splits::auto_reset_safe(&splits);
                 }
 
+                #[cfg(debug_assertions)]
+                let mut scenes_grub_rescued = game_manager_finder.scenes_grub_rescued(&process);
+                #[cfg(debug_assertions)]
+                asr::print_message(&format!("scenes_grub_rescued: {:?}", scenes_grub_rescued));
+
                 let mut last_timer_state = TimerState::Unknown;
                 let mut i = 0;
                 loop {
                     tick_action(&process, &splits, &mut last_timer_state, &mut i, auto_reset, &game_manager_finder, &mut scene_store, &mut player_data_store, &mut load_remover).await;
 
                     load_remover.load_removal(&process, &game_manager_finder, i);
+
+                    #[cfg(debug_assertions)]
+                    let new_scenes_grub_rescued = game_manager_finder.scenes_grub_rescued(&process);
+                    #[cfg(debug_assertions)]
+                    if new_scenes_grub_rescued != scenes_grub_rescued {
+                        scenes_grub_rescued = new_scenes_grub_rescued;
+                        asr::print_message(&format!("scenes_grub_rescued: {:?}", scenes_grub_rescued));
+                    }
 
                     ticks_since_gui += 1;
                     if TICKS_PER_GUI <= ticks_since_gui && gui.load_update_store_if_unchanged() {

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -268,6 +268,10 @@ pub enum Split {
     /// 
     /// Splits on transition after Isma's Tear acquired
     TransTear,
+    /// Isma's Tear with Grub (Transition)
+    /// 
+    /// Splits on transition after collecting Isma's Tear and saving the grub in Isma's Grove
+    TransTearWithGrub,
     /// Main Menu w/ Isma's Tear (Menu)
     /// 
     /// Splits on transition to the main menu after Isma's Tear acquired
@@ -2772,6 +2776,7 @@ pub fn transition_splits(s: &Split, p: &Pair<&str>, prc: &Process, g: &GameManag
         Split::WaterwaysEntry => should_split(starts_with_any(p.current, WATERWAYS_ENTRY_SCENES) && p.current != p.old),
         Split::DungDefenderExit => should_split(p.old == "Waterways_05" && p.current == "Abyss_01"),
         Split::TransTear => should_split(pds.has_acid_armour(prc, g) && p.current != p.old),
+        Split::TransTearWithGrub => should_split(pds.has_acid_armour(prc, g) && pds.grub_waterways_isma(prc, g) && p.current != p.old),
         Split::MenuIsmasTear => should_split(pds.has_acid_armour(prc, g) && is_menu(p.current)),
         Split::EnterJunkPit => should_split(p.current == "GG_Waterways" && p.current != p.old),
         // endregion: Waterways

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1176,6 +1176,10 @@ pub enum Split {
     /// 
     /// Splits when rescuing the grub in Ruins1_05
     GrubCityBelowSanctum,
+    /// Rescued Grub City Collector All (Grub)
+    /// 
+    /// Splits when rescuing all three grubs in Ruins2_11. (On 1221, splits for right grub)
+    GrubCityCollectorAll,
     /// Rescued Grub City Guard House (Grub)
     /// 
     /// Splits when rescuing the grub in Ruins_House_01
@@ -3203,6 +3207,7 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::GrubBasinWings => should_split(pds.incremented_grubs_collected(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Abyss_19")),
         Split::GrubCityBelowLoveTower => should_split(pds.incremented_grubs_collected(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Ruins2_07")),
         Split::GrubCityBelowSanctum => should_split(pds.incremented_grubs_collected(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Ruins1_05")),
+        Split::GrubCityCollectorAll => should_split(g.scenes_grub_rescued(p).is_some_and(|s| s.contains(&"Ruins2_11".to_string()))),
         Split::GrubCityGuardHouse => should_split(pds.incremented_grubs_collected(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Ruins_House_01")),
         Split::GrubCitySanctum => should_split(pds.incremented_grubs_collected(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Ruins1_32")),
         Split::GrubCitySpire => should_split(pds.incremented_grubs_collected(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Ruins2_03")),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1459,6 +1459,67 @@ pub enum Split {
     /// 
     /// Splits upon obtaining 2400 Essence
     Essence2400,
+    /// Whispering Root (Ancestral Mound)
+    /// 
+    /// Splits upon completing the whispering root in the Ancestral Mound
+    TreeMound,
+    /// Whispering Root (City of Tears)
+    /// 
+    /// Splits upon completing the whispering root in the City of Tears
+    TreeCity,
+    /// Whispering Root (Crystal Peak)
+    /// 
+    /// Splits upon completing the whispering root in Crystal Peak
+    TreePeak,
+    /// Whispering Root (Deepnest)
+    /// 
+    /// Splits upon completing the whispering root in Deepnest
+    TreeDeepnest,
+    /// Whispering Root (Forgotten Crossroads)
+    /// 
+    /// Splits upon completing the whispering root in the Forgotten Crossroads
+    TreeCrossroads,
+    /// Whispering Root (Leg Eater)
+    /// 
+    /// Splits upon completing the whispering root left from Leg Eater
+    TreeLegEater,
+    /// Whispering Root (Mantis Village)
+    /// 
+    /// Splits upon completing the whispering root above the Mantis Village
+    TreeMantisVillage,
+    /// Whispering Root (Greenpath)
+    /// 
+    /// Splits upon completing the whispering root in Greenpath
+    TreeGreenpath,
+    /// Whispering Root (Hive)
+    /// 
+    /// Splits upon completing the whispering root in the Hive
+    TreeHive,
+    /// Whispering Root (Howling Cliffs)
+    /// 
+    /// Splits upon completing the whispering root in the Howling Cliifs
+    TreeCliffs,
+    /// Whispering Root (Kingdom's Edge)
+    /// 
+    /// Splits upon completing the whispering root in the Kingdom's Edge
+    TreeKingdomsEdge,
+    /// Whispering Root (Queen's Gardens)
+    /// 
+    /// Splits upon completing the whispering root in the Queen's Gardens
+    TreeQueensGardens,
+    /// Whispering Root (Resting Grounds)
+    /// 
+    /// Splits upon completing the whispering root in the Resting Grounds
+    TreeRestingGrounds,
+    /// Whispering Root (Royal Waterways)
+    /// 
+    /// Splits upon completing the whispering root in the Royal Waterways
+    TreeWaterways,
+    /// Whispering Root (Spirits' Glade)
+    /// 
+    /// Splits upon completing the whispering root in the Spirits' Glade
+    TreeGlade,
+
     /// Dream Nail Marissa (Obtain)
     /// 
     /// Splits when obtaining the essence from Marissa
@@ -3287,6 +3348,21 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::Essence2200 => should_split(g.dream_orbs(p).is_some_and(|o| 2200 <= o)),
         Split::Essence2300 => should_split(g.dream_orbs(p).is_some_and(|o| 2300 <= o)),
         Split::Essence2400 => should_split(g.dream_orbs(p).is_some_and(|o| 2400 <= o)),
+        Split::TreeCity => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Ruins1_17".to_string()))),
+        Split::TreeCliffs => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Cliffs_01".to_string()))),
+        Split::TreeCrossroads => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Crossroads_07".to_string()))),
+        Split::TreeDeepnest => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Deepnest_39".to_string()))),
+        Split::TreeGlade => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"RestingGrounds_08".to_string()))),
+        Split::TreeGreenpath => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Fungus1_13".to_string()))),
+        Split::TreeHive => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Hive_02".to_string()))),
+        Split::TreeKingdomsEdge => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Deepnest_East_07".to_string()))),
+        Split::TreeLegEater => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Fungus2_33".to_string()))),
+        Split::TreeMantisVillage => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Fungus2_17".to_string()))),
+        Split::TreeMound => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Crossroads_ShamanTemple".to_string()))),
+        Split::TreePeak => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Mines_23".to_string()))),
+        Split::TreeQueensGardens => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Fungus3_11".to_string()))),
+        Split::TreeRestingGrounds => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"RestingGrounds_05".to_string()))),
+        Split::TreeWaterways => should_split(g.scenes_encountered_dream_plant_c(p).is_some_and(|s| s.contains(&"Abyss_01".to_string()))),
         Split::OnObtainGhostMarissa => should_split(pds.incremented_dream_orbs(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Ruins_Bathhouse")),
         Split::OnObtainGhostCaelifFera => should_split(pds.incremented_dream_orbs(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Fungus1_24")),
         Split::OnObtainGhostPoggy => should_split(pds.incremented_dream_orbs(p, g) && g.get_scene_name(p).is_some_and(|s| s == "Ruins_Elevator")),

--- a/src/splits.rs
+++ b/src/splits.rs
@@ -1910,6 +1910,10 @@ pub enum Split {
     /// 
     /// Splits when getting Soul Tyrant essence
     SoulTyrantEssence,
+    /// Soul Tyrant w/ Sanctum Grub (Essence)
+    /// 
+    /// Splits when getting Soul Tyrant essence and Sanctum fakedive grub
+    SoulTyrantEssenceWithSanctumGrub,
     MenuStoreroomsSimpleKey,
     EnterBlackKnight,
     /// Chandelier - Watcher Knights (Event)
@@ -3384,6 +3388,8 @@ pub fn continuous_splits(s: &Split, p: &Process, g: &GameManagerFinder, pds: &mu
         Split::SoulMaster => should_split(g.killed_mage_lord(p).is_some_and(|k| k)),
         Split::SoulTyrant => should_split(g.mage_lord_dream_defeated(p).is_some_and(|k| k)),
         Split::SoulTyrantEssence => should_split(g.mage_lord_orbs_collected(p).is_some_and(|o| o)),
+        Split::SoulTyrantEssenceWithSanctumGrub => should_split(g.mage_lord_orbs_collected(p).is_some_and(|o| o)
+                                                                && g.scenes_grub_rescued(p).is_some_and(|s| s.contains(&"Ruins1_32".to_string()))),
         Split::WatcherChandelier => should_split(g.watcher_chandelier(p).is_some_and(|c| c)),
         Split::BlackKnight => should_split(g.killed_black_knight(p).is_some_and(|k| k)),
         Split::BlackKnightTrans => { pds.killed_black_knight(p, g); should_split(false) },


### PR DESCRIPTION
Splits using `mem.PlayerDataStringList` with `scenesGrubRescued`, `scenesEncounteredDreamPlantC`.